### PR TITLE
chore: migrate codeowners to managed team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owner
-* @DataDog/serverless-azure-gcp
+* @DataDog/serverless-azure-and-gcp


### PR DESCRIPTION
Migrates this repo to the managed identity team