### PR TITLE
fix: update broken link for 1st gen cloud run functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Datadog library for Go to enable tracing and custom metric submission from [Goog
 
 # Getting Started
 
-- [Install Serverless Monitoring for Google Cloud Run Functions (1st gen)](https://docs.datadoghq.com/serverless/google_cloud_run/functions_gen1?code-lang=go)
+- [Install Serverless Monitoring for Google Cloud Run Functions (1st gen)](https://docs.datadoghq.com/serverless/google_cloud_run/functions_1st_gen/?tab=go)
 
 ## Testing
 tests can be run with `go test -v ./datadogserverlesscompat` or by utilizing the dockerfile to run the tests in a linux container


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [x] Documentation Update

## Description

Fixes broken link to Datadog public docs for instrumenting 1st Gen Cloud Run Functions.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
